### PR TITLE
Dependency updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,20 @@ GEM
   remote: https://rubygems.org/
   specs:
     byebug (11.0.1)
-    hashdiff (1.0.0)
+    hashdiff (1.0.1)
     httparty (0.17.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (2.3.0)
+    json (2.3.1)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.1009)
-    mini_mime (1.0.2)
+    mime-types-data (3.2022.0105)
+    mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     multi_xml (0.6.0)
-    nokogiri (1.13.5)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     pony (1.13.1)
@@ -34,4 +34,4 @@ DEPENDENCIES
   pony (~> 1.13.0)
 
 BUNDLED WITH
-   2.0.2
+   2.3.10


### PR DESCRIPTION
Direct dependencies:

  * hashdiff (1.0.1)
  * json (2.3.1)
  * nokogiri (1.13.6)

Transitive dependencies:

  * mime-types (3.4.1)
  * mime-types-data (3.2022.0105)
  * mini_mime (1.1.2)